### PR TITLE
Issue 29 log folder bug

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -35,24 +35,6 @@ def add_common_namespaces(doctest_namespace):
 
 
 @pytest.fixture(scope="function")
-def adversarial_logdir():
-    """Add the logdir parameter to tests."""
-    m_adversarial_logdir = "testlog/adversarial"
-
-    # Clean before
-    if os.path.exists(m_adversarial_logdir):
-        shutil.rmtree(m_adversarial_logdir)
-        assert not os.path.exists(m_adversarial_logdir)
-
-    yield m_adversarial_logdir
-
-    # Teardown
-    if os.path.exists(m_adversarial_logdir):
-        shutil.rmtree(m_adversarial_logdir)
-        assert not os.path.exists(m_adversarial_logdir)
-
-
-@pytest.fixture(scope="function")
 def save_dir():
     """Add the save_dir parameter to tests."""
     m_save_dir = "testlog/savedir"

--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -75,6 +75,7 @@ extensions = [
     "sphinx.ext.graphviz",
     "m2r",
     "sphinx_autodoc_typehints",
+    "sphinx_copybutton",
 ]
 
 # Autodoc

--- a/requirements.in/docs.txt
+++ b/requirements.in/docs.txt
@@ -6,4 +6,5 @@ pydocstyle
 sphinx
 sphinx-autobuild
 sphinx-autodoc-typehints
+sphinx-copybutton
 sphinx-rtd-theme

--- a/requirements.txt
+++ b/requirements.txt
@@ -21,11 +21,13 @@ click==7.0                # via black
 codecov==2.0.15
 coverage==5.0.3           # via codecov, pytest-cov
 doc8==0.8.0
-docutils==0.16            # via doc8, restructuredtext-lint, sphinx
+docutils==0.16            # via doc8, flit, restructuredtext-lint, sphinx
 entrypoints==0.3          # via flake8
 filelock==3.0.12          # via tox
 flake8-bugbear==20.1.2
 flake8==3.7.9
+flit-core==2.2.0          # via flit
+flit==2.2.0               # via sphinx-copybutton
 gast==0.2.2               # via tensorflow
 google-auth-oauthlib==0.4.1  # via tensorboard
 google-auth==1.10.1       # via google-auth-oauthlib, tensorboard
@@ -68,11 +70,12 @@ pylint==2.4.4
 pyparsing==2.4.6          # via packaging
 pytest-cov==2.8.1
 pytest==5.3.3
+pytoml==0.1.21            # via flit, flit-core
 pytz==2019.3              # via babel
 pyyaml==5.3               # via sphinx-autobuild, watchdog
 regex==2020.1.8           # via black
 requests-oauthlib==1.3.0  # via google-auth-oauthlib
-requests==2.22.0          # via codecov, requests-oauthlib, sphinx, tensorboard
+requests==2.22.0          # via codecov, flit, requests-oauthlib, sphinx, tensorboard
 restructuredtext-lint==1.3.0  # via doc8
 rope==0.16.0
 rsa==4.0                  # via google-auth
@@ -81,6 +84,7 @@ six==1.14.0               # via absl-py, astroid, doc8, google-auth, google-past
 snowballstemmer==2.0.0    # via pydocstyle, sphinx
 sphinx-autobuild==0.7.1
 sphinx-autodoc-typehints==1.10.3
+sphinx-copybutton==0.2.8
 sphinx-rtd-theme==0.4.3
 sphinx==2.3.1
 sphinxcontrib-applehelp==1.0.1  # via sphinx
@@ -105,7 +109,7 @@ virtualenv==16.7.9        # via tox
 watchdog==0.9.0           # via sphinx-autobuild
 wcwidth==0.1.8            # via pytest
 werkzeug==0.16.0          # via tensorboard
-wheel==0.33.6             # via tensorboard, tensorflow
+wheel==0.33.6             # via sphinx-copybutton, tensorboard, tensorflow
 wrapt==1.11.2             # via astroid, tensorflow
 zipp==2.0.0               # via importlib-metadata
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -21,11 +21,13 @@ click==7.0                # via black
 codecov==2.0.15
 coverage==5.0.3           # via codecov, pytest-cov
 doc8==0.8.0
-docutils==0.16            # via doc8, restructuredtext-lint, sphinx
+docutils==0.16            # via doc8, flit, restructuredtext-lint, sphinx
 entrypoints==0.3          # via flake8
 filelock==3.0.12          # via tox
 flake8-bugbear==20.1.2
 flake8==3.7.9
+flit-core==2.2.0          # via flit
+flit==2.2.0               # via sphinx-copybutton
 gast==0.2.2               # via tensorflow
 google-auth-oauthlib==0.4.1  # via tensorboard
 google-auth==1.10.1       # via google-auth-oauthlib, tensorboard
@@ -68,11 +70,12 @@ pylint==2.4.4
 pyparsing==2.4.6          # via packaging
 pytest-cov==2.8.1
 pytest==5.3.3
+pytoml==0.1.21            # via flit, flit-core
 pytz==2019.3              # via babel
 pyyaml==5.3               # via sphinx-autobuild, watchdog
 regex==2020.1.8           # via black
 requests-oauthlib==1.3.0  # via google-auth-oauthlib
-requests==2.22.0          # via codecov, requests-oauthlib, sphinx, tensorboard
+requests==2.22.0          # via codecov, flit, requests-oauthlib, sphinx, tensorboard
 restructuredtext-lint==1.3.0  # via doc8
 rope==0.16.0
 rsa==4.0                  # via google-auth
@@ -81,6 +84,7 @@ six==1.14.0               # via absl-py, astroid, doc8, google-auth, google-past
 snowballstemmer==2.0.0    # via pydocstyle, sphinx
 sphinx-autobuild==0.7.1
 sphinx-autodoc-typehints==1.10.3
+sphinx-copybutton==0.2.8
 sphinx-rtd-theme==0.4.3
 sphinx==2.3.1
 sphinxcontrib-applehelp==1.0.1  # via sphinx
@@ -105,7 +109,7 @@ virtualenv==16.7.9        # via tox
 watchdog==0.9.0           # via sphinx-autobuild
 wcwidth==0.1.8            # via pytest
 werkzeug==0.16.0          # via tensorboard
-wheel==0.33.6             # via tensorboard, tensorflow
+wheel==0.33.6             # via sphinx-copybutton, tensorboard, tensorflow
 wrapt==1.11.2             # via astroid, tensorflow
 zipp==2.0.0               # via importlib-metadata
 

--- a/requirements/docs.txt
+++ b/requirements/docs.txt
@@ -10,7 +10,9 @@ babel==2.8.0              # via sphinx
 certifi==2019.11.28       # via requests
 chardet==3.0.4            # via doc8, requests
 doc8==0.8.0
-docutils==0.16            # via doc8, restructuredtext-lint, sphinx
+docutils==0.16            # via doc8, flit, restructuredtext-lint, sphinx
+flit-core==2.2.0          # via flit
+flit==2.2.0               # via sphinx-copybutton
 idna==2.8                 # via requests
 imagesize==1.2.0          # via sphinx
 jinja2==2.10.3            # via sphinx
@@ -23,14 +25,16 @@ port_for==0.3.1           # via sphinx-autobuild
 pydocstyle==5.0.2
 pygments==2.5.2           # via sphinx
 pyparsing==2.4.6          # via packaging
+pytoml==0.1.21            # via flit, flit-core
 pytz==2019.3              # via babel
 pyyaml==5.3               # via sphinx-autobuild, watchdog
-requests==2.22.0          # via sphinx
+requests==2.22.0          # via flit, sphinx
 restructuredtext-lint==1.3.0  # via doc8
 six==1.14.0               # via doc8, livereload, packaging, stevedore
 snowballstemmer==2.0.0    # via pydocstyle, sphinx
 sphinx-autobuild==0.7.1
 sphinx-autodoc-typehints==1.10.3
+sphinx-copybutton==0.2.8
 sphinx-rtd-theme==0.4.3
 sphinx==2.3.1
 sphinxcontrib-applehelp==1.0.1  # via sphinx
@@ -43,6 +47,7 @@ stevedore==1.31.0         # via doc8
 tornado==6.0.3            # via livereload, sphinx-autobuild
 urllib3==1.25.7           # via requests
 watchdog==0.9.0           # via sphinx-autobuild
+wheel==0.33.6             # via sphinx-copybutton
 
 # The following packages are considered to be unsafe in a requirements file:
 # setuptools

--- a/src/ashpy/metrics/metric.py
+++ b/src/ashpy/metrics/metric.py
@@ -67,7 +67,6 @@ class Metric(ABC):
         self._metric = metric
         self._model_selection_operator = model_selection_operator
         self._logdir = logdir
-        self._update_logdir()
 
     def model_selection(
         self, checkpoint: tf.train.Checkpoint, global_step: tf.Variable

--- a/src/ashpy/trainers/classifier.py
+++ b/src/ashpy/trainers/classifier.py
@@ -130,9 +130,7 @@ class ClassifierTrainer(Trainer):
         else:
             metrics = [self._avg_loss]
 
-        for metric in metrics:
-            metric.logdir = self._logdir
-        self._metrics = metrics
+        super()._update_metrics(metrics)
 
         self._checkpoint.objects.extend([self._optimizer, self._model])
         self._restore_or_init()

--- a/src/ashpy/trainers/gan.py
+++ b/src/ashpy/trainers/gan.py
@@ -78,7 +78,6 @@ class AdversarialTrainer(Trainer):
                         output_shape=10,
                     ),
                     model_selection_operator=operator.gt,
-                    logdir=logdir,
                 )
             ]
             trainer = trainers.gan.AdversarialTrainer(
@@ -194,7 +193,7 @@ class AdversarialTrainer(Trainer):
         else:
             metrics = losses_metrics
 
-        self._metrics = metrics
+        super()._update_metrics(metrics)
 
         self._generator_optimizer = generator_optimizer
         self._discriminator_optimizer = discriminator_optimizer
@@ -430,7 +429,6 @@ class EncoderTrainer(AdversarialTrainer):
                 metrics.gan.EncodingAccuracy(
                     classifier,
                     # model_selection_operator=operator.gt,
-                    logdir=logdir
                 )
             ]
 
@@ -526,6 +524,9 @@ class EncoderTrainer(AdversarialTrainer):
                 track of the training steps.
 
         """
+        if not metrics:
+            metrics = []
+        metrics.append(EncoderLoss(logdir=logdir))
         super().__init__(
             generator=generator,
             discriminator=discriminator,
@@ -547,7 +548,6 @@ class EncoderTrainer(AdversarialTrainer):
         self._encoder_loss = encoder_loss
         self._encoder_loss.reduction = tf.losses.Reduction.NONE
 
-        self._metrics.append(EncoderLoss(logdir=logdir))
         self._checkpoint.objects.extend([self._encoder, self._encoder_optimizer])
         self._restore_or_init()
 

--- a/src/ashpy/trainers/trainer.py
+++ b/src/ashpy/trainers/trainer.py
@@ -145,6 +145,12 @@ class Trainer(ABC):
         """Check if every callback is an :py:class:`ashpy.callbacks.Callback`."""
         validate_objects(self._callbacks, Callback)
 
+    def _update_metrics(self, metrics):
+        if metrics:
+            for metric in metrics:
+                metric.logdir = self._logdir
+            self._metrics = metrics
+
     def _update_global_batch_size(
         self,
         dataset: tf.data.Dataset,

--- a/tests/callbacks/test_callbacks.py
+++ b/tests/callbacks/test_callbacks.py
@@ -17,12 +17,10 @@
 from ashpy.callbacks.events import Event
 from ashpy.callbacks.gan import LogImageGANCallback
 
-from tests.utils.fake_training_loop import fake_training_loop
+from tests.utils.fake_training_loop import fake_adversarial_training_loop
 
 
-def test_callbacks(adversarial_logdir: str):
+def test_callbacks(tmpdir):
     """Test the integration between callbacks and trainer."""
-
     callbacks = [LogImageGANCallback(event=Event.ON_BATCH_END, event_freq=1)]
-
-    fake_training_loop(adversarial_logdir, callbacks=callbacks)
+    fake_adversarial_training_loop(tmpdir, callbacks=callbacks)

--- a/tests/callbacks/test_counter_callback.py
+++ b/tests/callbacks/test_counter_callback.py
@@ -19,7 +19,7 @@ import tensorflow as tf
 from ashpy.callbacks import CounterCallback, Event
 from ashpy.models.gans import ConvDiscriminator, ConvGenerator
 
-from tests.utils.fake_training_loop import fake_training_loop
+from tests.utils.fake_training_loop import fake_adversarial_training_loop
 
 
 class FakeCounterCallback(CounterCallback):
@@ -74,7 +74,7 @@ def test_counter_callback_multiple_events():
 
 
 # TODO: parametrize tests following test_save_callback.py
-def test_counter_callback(_models, adversarial_logdir):
+def test_counter_callback(_models, tmpdir):
     clbk = FakeCounterCallback(
         event=Event.ON_EPOCH_END,
         name="TestCounterCallback",
@@ -82,8 +82,8 @@ def test_counter_callback(_models, adversarial_logdir):
     )
     callbacks = [clbk]
     generator, discriminator = _models
-    fake_training_loop(
-        adversarial_logdir,
+    fake_adversarial_training_loop(
+        logdir=tmpdir,
         callbacks=callbacks,
         generator=generator,
         discriminator=discriminator,

--- a/tests/callbacks/test_custom_callback.py
+++ b/tests/callbacks/test_custom_callback.py
@@ -18,7 +18,7 @@ import pytest
 from ashpy.callbacks import Callback
 from ashpy.callbacks.events import Event
 
-from tests.utils.fake_training_loop import fake_training_loop
+from tests.utils.fake_training_loop import fake_adversarial_training_loop
 
 
 class MCallback(Callback):
@@ -55,7 +55,7 @@ def get_n_events_from_epochs(
 
 
 @pytest.mark.parametrize("event", list(Event))
-def test_custom_callbacks(adversarial_logdir: str, event: Event):
+def test_custom_callbacks(tmpdir, event: Event):
     """Test the integration between a custom callback and a trainer."""
     m_callback = MCallback(event)
     callbacks = [m_callback]
@@ -64,8 +64,8 @@ def test_custom_callbacks(adversarial_logdir: str, event: Event):
     dataset_size = 2
     batch_size = 2
 
-    fake_training_loop(
-        adversarial_logdir,
+    fake_adversarial_training_loop(
+        logdir=tmpdir,
         callbacks=callbacks,
         epochs=epochs,
         dataset_size=dataset_size,

--- a/tests/callbacks/test_save_callback.py
+++ b/tests/callbacks/test_save_callback.py
@@ -20,7 +20,7 @@ import pytest
 from ashpy.callbacks import SaveCallback, SaveFormat, SaveSubFormat
 from ashpy.models.gans import ConvDiscriminator, ConvGenerator
 
-from tests.utils.fake_training_loop import fake_training_loop
+from tests.utils.fake_training_loop import fake_adversarial_training_loop
 
 COMPATIBLE_FORMAT_AND_SUB_FORMAT = [
     (SaveFormat.WEIGHTS, SaveSubFormat.TF),
@@ -33,15 +33,11 @@ INCOMPATIBLE_FORMAT_AND_SUB_FORMAT = [(SaveFormat.MODEL, SaveSubFormat.H5)]
 
 @pytest.mark.parametrize("save_format_and_sub_format", COMPATIBLE_FORMAT_AND_SUB_FORMAT)
 def test_save_callback_compatible(
-    adversarial_logdir: str,
-    save_format_and_sub_format: Tuple[SaveFormat, SaveSubFormat],
-    save_dir: str,
+    tmpdir, save_format_and_sub_format: Tuple[SaveFormat, SaveSubFormat], save_dir: str,
 ):
     """Test the integration between callbacks and trainer."""
     save_format, save_sub_format = save_format_and_sub_format
-    _test_save_callback_helper(
-        adversarial_logdir, save_format, save_sub_format, save_dir
-    )
+    _test_save_callback_helper(tmpdir, save_format, save_sub_format, save_dir)
 
     save_dirs = os.listdir(save_dir)
     # 2 folders: generator and discriminator
@@ -58,25 +54,19 @@ def test_save_callback_compatible(
     "save_format_and_sub_format", INCOMPATIBLE_FORMAT_AND_SUB_FORMAT
 )
 def test_save_callback_incompatible(
-    adversarial_logdir: str,
-    save_format_and_sub_format: Tuple[SaveFormat, SaveSubFormat],
-    save_dir: str,
+    tmpdir, save_format_and_sub_format: Tuple[SaveFormat, SaveSubFormat], save_dir: str,
 ):
     """Test the integration between callbacks and trainer."""
     save_format, save_sub_format = save_format_and_sub_format
 
     with pytest.raises(NotImplementedError):
-        _test_save_callback_helper(
-            adversarial_logdir, save_format, save_sub_format, save_dir
-        )
+        _test_save_callback_helper(tmpdir, save_format, save_sub_format, save_dir)
 
     # assert no folder has been created
     assert not os.path.exists(save_dir)
 
 
-def _test_save_callback_helper(
-    adversarial_logdir, save_format, save_sub_format, save_dir
-):
+def _test_save_callback_helper(tmpdir, save_format, save_sub_format, save_dir):
     image_resolution = (28, 28)
     layer_spec_input_res = (7, 7)
     layer_spec_target_res = (7, 7)
@@ -112,11 +102,8 @@ def _test_save_callback_helper(
         )
     ]
 
-    fake_training_loop(
-        adversarial_logdir,
-        callbacks=callbacks,
-        generator=generator,
-        discriminator=discriminator,
+    fake_adversarial_training_loop(
+        tmpdir, callbacks=callbacks, generator=generator, discriminator=discriminator,
     )
 
 

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -12,9 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-"""
-Test losses inside the AdversarialLossType Enum
-"""
+"""Test losses inside the AdversarialLossType Enum."""
+
 import pytest
 from ashpy.losses.gan import (
     AdversarialLossType,
@@ -22,21 +21,16 @@ from ashpy.losses.gan import (
     get_adversarial_loss_generator,
 )
 
-from tests.utils.fake_training_loop import fake_training_loop
+from tests.utils.fake_training_loop import fake_adversarial_training_loop
 
 
 @pytest.mark.parametrize("loss_type", list(AdversarialLossType))
-def test_losses(loss_type: AdversarialLossType, adversarial_logdir: str):
-    """
-    Test the integration between losses and trainer
-    """
-
+def test_losses(loss_type: AdversarialLossType, tmpdir):
+    """Test the integration between losses and trainer."""
     # Losses
     generator_loss = get_adversarial_loss_generator(loss_type)()
     discriminator_loss = get_adversarial_loss_discriminator(loss_type)()
 
-    fake_training_loop(
-        adversarial_logdir,
-        generator_loss=generator_loss,
-        discriminator_loss=discriminator_loss,
+    fake_adversarial_training_loop(
+        tmpdir, generator_loss=generator_loss, discriminator_loss=discriminator_loss,
     )

--- a/tests/utils/fake_datasets.py
+++ b/tests/utils/fake_datasets.py
@@ -1,0 +1,40 @@
+# Copyright 2020 Zuru Tech HK Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tensorflow as tf
+
+
+def fake_autoencoder_datasest(
+    dataset_size=10, image_resolution=(64, 64), channels=3, batch_size=5,
+):
+    """
+    Generate the test dataset for the fake Convolutional Autoencoder model.
+
+    For the Conv Autoencoder the dataset is composed by:
+        - inputs: images
+        - labels: images
+
+    """
+    inputs, labels = (
+        tf.zeros((dataset_size, image_resolution[0], image_resolution[1], channels)),
+        tf.zeros((dataset_size, image_resolution[0], image_resolution[1], channels)),
+    )
+    dataset = (
+        tf.data.Dataset.from_tensor_slices((inputs, labels))
+        .take(dataset_size)
+        .batch(batch_size)
+        .prefetch(1)
+    )
+
+    return dataset

--- a/tests/utils/fake_models.py
+++ b/tests/utils/fake_models.py
@@ -1,0 +1,42 @@
+# Copyright 2020 Zuru Tech HK Limited. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tensorflow as tf
+from ashpy.models.convolutional.autoencoders import Autoencoder
+
+
+def conv_autoencoder(
+    layer_spec_input_res=(64, 64),
+    layer_spec_target_res=(4, 4),
+    kernel_size=3,
+    initial_filters=16,
+    filters_cap=64,
+    encoding_dimension=50,
+    channels=3,
+) -> tf.keras.Model:
+    """Create a new Convolutinal Autoencoder."""
+    autoencoder = Autoencoder(
+        layer_spec_input_res=layer_spec_input_res,
+        layer_spec_target_res=layer_spec_target_res,
+        kernel_size=kernel_size,
+        initial_filters=initial_filters,
+        filters_cap=filters_cap,
+        encoding_dimension=encoding_dimension,
+        channels=channels,
+    )
+    # Encoding, representation = autoencoder(input)
+    inputs = tf.keras.layers.Input(shape=(64, 64, 3))
+    _, reconstruction = autoencoder(inputs)
+    model = tf.keras.Model(inputs=inputs, outputs=reconstruction)
+    return model

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py{36-37-38}, black, pylint, flake8, docs
+envlist = py{37,38}, black, pylint, flake8, docs
 isolated_build = True
 
 [testenv]
@@ -15,7 +15,7 @@ deps =
     -rrequirements/docs.txt
     -rrequirements/test.txt
 commands =
-    pytest -vvv --doctest-modules {envsitepackagesdir}/ashpy tests --cov=ashpy --cov-report term-missing
+    pytest {posargs} -vvv --doctest-modules {envsitepackagesdir}/ashpy tests --cov=ashpy --cov-report term-missing
 
 [testenv:black]
 description = Formatting with black and isort
@@ -23,7 +23,7 @@ deps =
     {[testenv]deps}
     -rrequirements/linting.txt
 commands =
-    isort -rc {toxinidir}/src {toxinidir}/tests
+    isort -rc {toxinidir}/src {toxinidir}/tests -sp {toxinidir}/pyproject.toml
     black {toxinidir}/src {toxinidir}/tests
 
 [testenv:pylint]


### PR DESCRIPTION
# Solve #29 

## Description

Moved the automatic log folder creation present in the Metrics, now it is triggered ONLY during the initialization of the various Trainers.
If a Trainer does something fancy with the metrics after the `super().__init__` call now it must manually (re)trigger `super().update_metrics(metrics)` Seet the two GANs Trainers as an example.

**NOTE:** with this change, Trainers always override the `logdir` argument passed to a Metric during its initialization. This was done already but each metric also self updated polluting the logsdir leading to thi bug.

Fixes #29 (issue)

## Type of change

- [x] Bugfix (i.e., a non-breaking change which fixes an issue)
- [x] Breaking change (i.e., a fix or feature that would cause existing functionality to not work as expected)
- [?] This change requires a documentation update

## How Has This Been Tested?

Complete test suite with `tox`

### Dependencies

Add `sphinx-copybutton` (it's awesome).

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [?] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
