### PR TITLE
Fix Trainer restart issues

### DIFF
--- a/src/ashpy/contexts/classifier.py
+++ b/src/ashpy/contexts/classifier.py
@@ -16,7 +16,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, Tuple, Optional
+from typing import TYPE_CHECKING, Optional, Tuple
 
 import tensorflow as tf  # pylint: disable=import-error
 from ashpy.contexts.context import Context

--- a/src/ashpy/contexts/classifier.py
+++ b/src/ashpy/contexts/classifier.py
@@ -16,7 +16,7 @@
 
 from __future__ import annotations
 
-from typing import TYPE_CHECKING, List, Optional
+from typing import TYPE_CHECKING, Tuple, Optional
 
 import tensorflow as tf  # pylint: disable=import-error
 from ashpy.contexts.context import Context
@@ -36,7 +36,7 @@ class ClassifierContext(Context):
         classifier_model: tf.keras.Model = None,
         loss: ClassifierLoss = None,  # ?: Do we really need to default these values to None?
         dataset: tf.data.Dataset = None,
-        metrics: List[Metric] = None,
+        metrics: Tuple[Metric] = None,
         log_eval_mode: LogEvalMode = LogEvalMode.TEST,
         global_step: tf.Variable = tf.Variable(
             0, name="global_step", trainable=False, dtype=tf.int64

--- a/src/ashpy/contexts/context.py
+++ b/src/ashpy/contexts/context.py
@@ -55,7 +55,6 @@ class Context:
         """
         self._distribute_strategy = tf.distribute.get_strategy()
 
-        # TODO: are metrics really needed right now?
         self._metrics = metrics if metrics else ()
         self._dataset = dataset
         self._log_eval_mode = log_eval_mode

--- a/src/ashpy/contexts/context.py
+++ b/src/ashpy/contexts/context.py
@@ -20,7 +20,7 @@ collections of variable encapsulated in a Python Class as a way to seamlessly
 handle information transfer.
 """
 
-from typing import List, Optional, Tuple
+from typing import Optional, Tuple
 
 import tensorflow as tf
 from ashpy.metrics import Metric

--- a/src/ashpy/contexts/context.py
+++ b/src/ashpy/contexts/context.py
@@ -20,9 +20,10 @@ collections of variable encapsulated in a Python Class as a way to seamlessly
 handle information transfer.
 """
 
-from typing import List, Optional
+from typing import List, Optional, Tuple
 
 import tensorflow as tf
+
 from ashpy.metrics import Metric
 from ashpy.modes import LogEvalMode
 
@@ -32,7 +33,7 @@ class Context:
 
     def __init__(
         self,
-        metrics: List[Metric] = None,
+        metrics: Tuple[Metric] = None,
         dataset: tf.data.Dataset = None,
         log_eval_mode: LogEvalMode = LogEvalMode.TEST,
         global_step=tf.Variable(0, name="global_step", trainable=False, dtype=tf.int64),
@@ -42,7 +43,7 @@ class Context:
         Initialize the Context.
 
         Args:
-            metrics (:obj:`list` of [:py:class:`ashpy.metrics.metric.Metric`]): List of
+            metrics (:obj:`tuple` of (:py:class:`ashpy.metrics.metric.Metric`)): List of
                 :py:class:`ashpy.metrics.metric.Metric` objects.
             dataset (:py:class:`tf.data.Dataset`): The dataset to use, that
                 contains everything needed to use the model in this context.
@@ -56,7 +57,7 @@ class Context:
         self._distribute_strategy = tf.distribute.get_strategy()
 
         # TODO: are metrics really needed right now?
-        self._metrics = metrics if metrics else []
+        self._metrics = metrics if metrics else ()
         self._dataset = dataset
         self._log_eval_mode = log_eval_mode
         self._global_step = global_step
@@ -98,12 +99,12 @@ class Context:
         self._dataset = _dataset
 
     @property
-    def metrics(self) -> List[Metric]:
+    def metrics(self) -> Tuple[Metric]:
         """
         Retrieve the metrics.
 
         Returns:
-            :obj:`list` of [:py:class:`ashpy.metrics.metric.Metric`].
+            :obj:`tuple` of (:py:class:`ashpy.metrics.metric.Metric`).
 
         """
         return self._metrics

--- a/src/ashpy/contexts/context.py
+++ b/src/ashpy/contexts/context.py
@@ -23,7 +23,6 @@ handle information transfer.
 from typing import List, Optional, Tuple
 
 import tensorflow as tf
-
 from ashpy.metrics import Metric
 from ashpy.modes import LogEvalMode
 

--- a/src/ashpy/metrics/metric.py
+++ b/src/ashpy/metrics/metric.py
@@ -113,13 +113,13 @@ class Metric(ABC):
         # write the initial value of the best metric
         if not self.best_model_sel_file.exists():
             self.best_model_sel_file.parent.mkdir(parents=True)
-        initial_value = (
-            np.inf if self._model_selection_operator is operator.lt else -np.inf
-        )
-        self.json_write(
-            self.best_model_sel_file,
-            {self.sanitized_name: str(initial_value), "step": 0},
-        )
+            initial_value = (
+                np.inf if self._model_selection_operator is operator.lt else -np.inf
+            )
+            self.json_write(
+                self.best_model_sel_file,
+                {self.sanitized_name: str(initial_value), "step": 0},
+            )
 
     @property
     def name(self) -> str:

--- a/src/ashpy/restorers/__init__.py
+++ b/src/ashpy/restorers/__init__.py
@@ -45,11 +45,12 @@ Restorers allow for easy restoration of tracked objects from :class:`tf.train.Ch
 
 from ashpy.restorers.classifier import ClassifierRestorer
 from ashpy.restorers.gan import AdversarialEncoderRestorer, AdversarialRestorer
-from ashpy.restorers.restorer import Restorer
+from ashpy.restorers.restorer import ModelNotConstructedError, Restorer
 
 __ALL__ = [
     "Restorer",
     "AdversarialRestorer",
     "AdversarialEncoderRestorer",
     "ClassifierRestorer",
+    "ModelNotConstructedError",
 ]

--- a/src/ashpy/restorers/restorer.py
+++ b/src/ashpy/restorers/restorer.py
@@ -120,6 +120,7 @@ class Restorer:
         as layers.weights.
 
         TODO: add docs for the exception.
+        TODO: add test case for the Sequential without input shape
         """
         try:
             if restored_model.weights == []:

--- a/src/ashpy/restorers/restorer.py
+++ b/src/ashpy/restorers/restorer.py
@@ -121,7 +121,12 @@ class Restorer:
 
         TODO: add docs for the exception.
         """
-        if restored_model.weights == []:
+        try:
+            if restored_model.weights == []:
+                raise ModelNotConstructedError
+        except AttributeError:
+            # A Sequential() buil without specifiyng the input shape can be treated as a
+            # sub-classed model for restoration purposes.
             raise ModelNotConstructedError
         return True
 

--- a/src/ashpy/restorers/restorer.py
+++ b/src/ashpy/restorers/restorer.py
@@ -24,8 +24,19 @@ import tensorflow as tf
 __ALL__ = ["Restorer, ModelNotConstructedError"]
 
 
-class ModelNotConstructedError(BaseException):
-    pass
+class ModelNotConstructedError(Exception):
+    """
+    Exception raised while restoring sub-classed Model before having called it on data.
+
+    Warning:
+        When restoring a :class:`tf.keras.Model` object from checkpoint assure that the
+        model has been correctly built and instantiated by firstly calling it on some
+        sample inputs. In the case of a model built with either the Sequential or
+        Functional API an exception will be raised; for a model built with the Chainer API
+        it will fail silently, restoration will be "successful" but no values will actually
+        be restored since there are no valid placeholder as the model has not be built yet.
+
+    """
 
 
 class Restorer:

--- a/src/ashpy/trainers/classifier.py
+++ b/src/ashpy/trainers/classifier.py
@@ -15,10 +15,11 @@
 """Primitive Trainer Interface."""
 
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import List, Optional, Tuple, Union
+
+import tensorflow as tf
 
 import ashpy
-import tensorflow as tf
 from ashpy.callbacks import Callback
 from ashpy.contexts.classifier import ClassifierContext
 from ashpy.datasets import wrap
@@ -41,7 +42,7 @@ class ClassifierTrainer(Trainer):
         optimizer: tf.optimizers.Optimizer,
         loss: ashpy.losses.ClassifierLoss,
         epochs: int,
-        metrics: Optional[List[Metric]] = None,
+        metrics: Optional[Union[Tuple[Metric], List[Metric]]] = None,
         callbacks: Optional[List[Callback]] = None,
         logdir: Union[Path, str] = Path().cwd() / "log",
         global_step: Optional[tf.Variable] = None,
@@ -56,7 +57,7 @@ class ClassifierTrainer(Trainer):
             loss (:obj:`ashpy.losses.classifier.ClassifierLoss`): A loss function built following
                 :py:mod:`ashpy.executors``.
             epochs (int): Number of training epochs.
-            metrics: (List): List of :py:class:`ashpy.metrics.metric.Metric` to
+            metrics: (Tuple/List): Tuple/List of :py:class:`ashpy.metrics.metric.Metric` to
                 measure on training and validation data.
             callbacks (List): List of :py:class:`ashpy.callbacks.callback.Callback` to
                 to call on events
@@ -136,9 +137,9 @@ class ClassifierTrainer(Trainer):
 
         self._avg_loss = ClassifierLoss(name="ashpy/avg_loss")
         if metrics:
-            metrics.append(self._avg_loss)
+            metrics = (*metrics, self._avg_loss)
         else:
-            metrics = [self._avg_loss]
+            metrics = (self._avg_loss,)
 
         super()._update_metrics(metrics)
         super()._validate_metrics()

--- a/src/ashpy/trainers/gan.py
+++ b/src/ashpy/trainers/gan.py
@@ -14,7 +14,7 @@
 
 """Collection of GANs trainers."""
 from pathlib import Path
-from typing import List, Optional, Union
+from typing import List, Optional, Union, Tuple
 
 import tensorflow as tf
 from ashpy.callbacks import Callback
@@ -138,7 +138,7 @@ class AdversarialTrainer(Trainer):
         generator_loss: Executor,
         discriminator_loss: Executor,
         epochs: int,
-        metrics: Optional[List[Metric]] = None,
+        metrics: Optional[Union[Tuple[Metric], List[Metric]]] = None,
         callbacks: Optional[List[Callback]] = None,
         logdir: Union[Path, str] = Path().cwd() / "log",
         log_eval_mode: LogEvalMode = LogEvalMode.TEST,
@@ -191,12 +191,12 @@ class AdversarialTrainer(Trainer):
         self._discriminator_loss = discriminator_loss
         self._discriminator_loss.reduction = tf.losses.Reduction.NONE
 
-        losses_metrics = [
+        losses_metrics = (
             DiscriminatorLoss(name="ashpy/d_loss", logdir=logdir),
             GeneratorLoss(name="ashpy/g_loss", logdir=logdir),
-        ]
+        )
         if metrics:
-            metrics.extend(losses_metrics)
+            metrics = (*metrics, *losses_metrics)
         else:
             metrics = losses_metrics
 

--- a/src/ashpy/trainers/trainer.py
+++ b/src/ashpy/trainers/trainer.py
@@ -19,6 +19,7 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 from typing import Dict, List, Optional, Tuple, Union
 
+import ashpy.restorers
 import tensorflow as tf
 from ashpy.callbacks import Callback
 from ashpy.contexts import Context
@@ -36,6 +37,7 @@ class Trainer(ABC):
     ckpt_id_global_step: str = "global_step"
     ckpt_id_steps_per_epoch: str = "steps_per_epoch"
     ckpt_id_callbacks: str = "callbacks"
+    _deferred_restoration: bool = False
 
     def __init__(
         self,
@@ -246,8 +248,23 @@ class Trainer(ABC):
     def _restore_or_init(self):
         """Restore or initialize the persistence layer (checkpoint)."""
         if self._manager.latest_checkpoint:
-            # FIX: trainer restoration when restarting
-            self._checkpoint.restore(self._manager.latest_checkpoint)
+            restorer = ashpy.restorers.Restorer(self._logdir)
+
+            # Check that at least the ids of the things we want to restore are present in
+            # the map
+            for k in self._ckpt_dict:
+                assert k in restorer.checkpoint_map
+                try:
+                    restorer.restore_object(self._ckpt_dict[k], k)
+                except ashpy.restorers.ModelNotConstructedError:
+                    print(
+                        "WARNING: Trying to restore a Model constructed via sub-classing"
+                        "API requires calling it on some data first."
+                        "More info -> "
+                        "https://www.tensorflow.org/guide/keras/save_and_serialize#saving_subclassed_models"  # pylint: disable=line-too-long
+                        "Restoration will be deferred at the beginning of the Trainer call."
+                    )
+                    self._deferred_restoration = True
             print(f"Restored checkpoint {self._manager.latest_checkpoint}.")
         else:
             print("Initializing checkpoint.")
@@ -373,6 +390,10 @@ class Trainer(ABC):
                     )
                 )
         return tuple(columns)
+
+    @abstractmethod
+    def _build_and_restore_models(self, dataset: tf.data.Dataset):
+        """Build and restore a Subclassed model by firstly calling it on some data."""
 
     @abstractmethod
     def call(self, *args, **kwargs):

--- a/tests/callbacks/__init__.py
+++ b/tests/callbacks/__init__.py
@@ -1,1 +1,6 @@
-"""Test for callbacks."""
+"""
+Test for callbacks.
+
+TODO: test a callback that retrieves a Metric from its Context
+TODO: Restructure these tests
+"""

--- a/tests/callbacks/test_callbacks.py
+++ b/tests/callbacks/test_callbacks.py
@@ -17,10 +17,10 @@
 from ashpy.callbacks import LogImageGANCallback
 from ashpy.callbacks.events import Event
 
-from tests.utils.fake_training_loop import fake_adversarial_training_loop
+from tests.utils.fake_training_loop import FakeAdversarialTraining
 
 
 def test_callbacks(tmpdir):
     """Test the integration between callbacks and trainer."""
     callbacks = [LogImageGANCallback(event=Event.ON_BATCH_END, event_freq=1)]
-    fake_adversarial_training_loop(tmpdir, callbacks=callbacks)
+    FakeAdversarialTraining(tmpdir, callbacks=callbacks)

--- a/tests/callbacks/test_counter_callback.py
+++ b/tests/callbacks/test_counter_callback.py
@@ -18,7 +18,7 @@ import pytest
 from ashpy.callbacks import CounterCallback, Event
 from ashpy.models.gans import ConvDiscriminator, ConvGenerator
 
-from tests.utils.fake_training_loop import fake_adversarial_training_loop
+from tests.utils.fake_training_loop import FakeAdversarialTraining
 
 
 class FakeCounterCallback(CounterCallback):
@@ -81,11 +81,11 @@ def test_counter_callback(_models, tmpdir):
     )
     callbacks = [clbk]
     generator, discriminator = _models
-    fake_adversarial_training_loop(
+    FakeAdversarialTraining(
         logdir=tmpdir,
         callbacks=callbacks,
         generator=generator,
         discriminator=discriminator,
         epochs=1,
-    )
+    )()
     assert clbk.fake_counter == 1

--- a/tests/callbacks/test_custom_callback.py
+++ b/tests/callbacks/test_custom_callback.py
@@ -18,7 +18,7 @@ import pytest
 from ashpy.callbacks import Callback
 from ashpy.callbacks.events import Event
 
-from tests.utils.fake_training_loop import fake_adversarial_training_loop
+from tests.utils.fake_training_loop import FakeAdversarialTraining
 
 
 class MCallback(Callback):
@@ -65,13 +65,13 @@ def test_custom_callbacks(tmpdir, event: Event):
     dataset_size = 2
     batch_size = 2
 
-    fake_adversarial_training_loop(
+    FakeAdversarialTraining(
         logdir=tmpdir,
         callbacks=callbacks,
         epochs=epochs,
         dataset_size=dataset_size,
         batch_size=batch_size,
-    )
+    )()
 
     # assert the number of times the on_event has been called
     assert m_callback.counter == get_n_events_from_epochs(

--- a/tests/callbacks/test_save_callback.py
+++ b/tests/callbacks/test_save_callback.py
@@ -21,7 +21,7 @@ import pytest
 from ashpy.callbacks import SaveCallback, SaveFormat, SaveSubFormat
 from ashpy.models.gans import ConvDiscriminator, ConvGenerator
 
-from tests.utils.fake_training_loop import fake_adversarial_training_loop
+from tests.utils.fake_training_loop import FakeAdversarialTraining
 
 COMPATIBLE_FORMAT_AND_SUB_FORMAT = [
     (SaveFormat.WEIGHTS, SaveSubFormat.TF),
@@ -106,9 +106,9 @@ def _test_save_callback_helper(tmpdir, save_format, save_sub_format, save_dir: P
         )
     ]
 
-    fake_adversarial_training_loop(
+    FakeAdversarialTraining(
         tmpdir, callbacks=callbacks, generator=generator, discriminator=discriminator,
-    )
+    )()
 
 
 def test_save_callback_type_error(save_dir: str,):

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -21,7 +21,7 @@ from ashpy.losses.gan import (
     get_adversarial_loss_generator,
 )
 
-from tests.utils.fake_training_loop import fake_adversarial_training_loop
+from tests.utils.fake_training_loop import FakeAdversarialTraining
 
 
 @pytest.mark.parametrize("loss_type", list(AdversarialLossType))
@@ -31,6 +31,6 @@ def test_losses(loss_type: AdversarialLossType, tmpdir):
     generator_loss = get_adversarial_loss_generator(loss_type)()
     discriminator_loss = get_adversarial_loss_discriminator(loss_type)()
 
-    fake_adversarial_training_loop(
+    FakeAdversarialTraining(
         tmpdir, generator_loss=generator_loss, discriminator_loss=discriminator_loss,
     )

--- a/tests/test_losses.py
+++ b/tests/test_losses.py
@@ -33,4 +33,4 @@ def test_losses(loss_type: AdversarialLossType, tmpdir):
 
     FakeAdversarialTraining(
         tmpdir, generator_loss=generator_loss, discriminator_loss=discriminator_loss,
-    )
+    )()

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -123,21 +123,23 @@ def test_metrics_names_collision(tmpdir):
 # -------------------------------------------------------------------------------------
 
 
-# def test_metrics_on_restart(fake_training, tmpdir):
-#     """Test that metrics are correctly read on train restart."""
+def test_metrics_on_restart(fake_training_fn, tmpdir):
+    """Test that metrics are correctly read on train restart."""
 
-#     def _train(fake_training, tmpdir):
-#         training_loop, loop_args, metrics = fake_training
-#         training_completed, trainer = training_loop(
-#             logdir=tmpdir, metrics=metrics, **loop_args
-#         )
-#         assert training_completed
-#         # Read and store the values of the metrics
-#         metrics_values = {
-#             metric.name: get_metric_data(metric, tmpdir) for metric in trainer._metrics
-#         }
-#         return metrics_values
+    fake_training = fake_training_fn(tmpdir)
+    assert fake_training()
 
-#     t1_values = _train(fake_training, tmpdir)
-#     t2_values = _train(fake_training, tmpdir)
-#     assert t1_values == t2_values
+    t1_values = {
+        metric.name: get_metric_data(metric, tmpdir)
+        for metric in fake_training.trainer._metrics
+    }
+    print(t1_values)
+
+    restart = fake_training_fn(tmpdir)
+
+    t2_values = {
+        metric.name: get_metric_data(metric, tmpdir)
+        for metric in restart.trainer._metrics
+    }
+    print(t2_values)
+    assert t1_values == t2_values

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -19,13 +19,13 @@ TODO: Adversarial Encoder Traner
 """
 import json
 import operator
-import pathlib
 import shutil
+from pathlib import Path
 
 import pytest
 from ashpy.metrics import ClassifierLoss
 
-from tests.utils.fake_training_loop import fake_classifier_training_loop
+from tests.utils.fake_training_loop import FakeAdversarialTraining, FakeTraining
 
 DEFAULT_LOGDIR = "log"
 OPERATOR_INITIAL_VALUE_MAP = {operator.gt: "-inf", operator.lt: "inf"}
@@ -34,7 +34,7 @@ OPERATOR_INITIAL_VALUE_MAP = {operator.gt: "-inf", operator.lt: "inf"}
 @pytest.fixture(scope="module")
 def cleanup():
     """Remove the default logdir before and after testing."""
-    default_log_dir = pathlib.Path(DEFAULT_LOGDIR)
+    default_log_dir = Path(DEFAULT_LOGDIR)
     if default_log_dir.exists():
         shutil.rmtree(default_log_dir)
     yield "Cleanup"
@@ -42,7 +42,22 @@ def cleanup():
         shutil.rmtree(default_log_dir)
 
 
-def test_metrics_log(fake_training, tmpdir, cleanup):
+def get_metric_data(metric, tmpdir):
+    """Make sure that the metric exists and is readable. Return its value."""
+    metric_dir = Path(tmpdir) / "best" / metric.sanitized_name
+    assert metric_dir.exists()
+    json_path = metric_dir / f"{metric.sanitized_name}.json"
+    assert json_path.exists()
+    with open(json_path, "r") as fp:
+        metric_data = json.load(fp)
+
+        # Assert the metric data contains the expected keys
+        assert metric.sanitized_name in metric_data
+        assert "step" in metric_data
+        return metric_data[metric.sanitized_name]
+
+
+def test_metrics_log(fake_training_fn, tmpdir, cleanup):
     """
     Test that trainers correctly create metrics log files.
 
@@ -57,52 +72,72 @@ def test_metrics_log(fake_training, tmpdir, cleanup):
         THEN the values of the keys should not be the operator initial value
 
     """
-    training_loop, loop_args, metrics = fake_training
+    logdir = Path(tmpdir)
 
-    training_completed, trainer = training_loop(
-        logdir=tmpdir, metrics=metrics, **loop_args
-    )
+    fake_training: FakeTraining = fake_training_fn(logdir=logdir)
+    assert fake_training()
+    trainer = fake_training.trainer
 
-    assert training_completed
-    assert not pathlib.Path(DEFAULT_LOGDIR).exists()  # Assert absence of side effects
+    assert not Path(DEFAULT_LOGDIR).exists()  # Assert absence of side effects
     # Assert there exists folder for each metric
     for metric in trainer._metrics:
-        metric_dir = pathlib.Path(tmpdir) / "best" / metric.sanitized_name
-        assert metric_dir.exists()
-        json_path = metric_dir / f"{metric.sanitized_name}.json"
-        assert json_path.exists()
-        with open(json_path, "r") as fp:
-            metric_data = json.load(fp)
 
-            # Assert the metric data contains the expected keys
-            assert metric.sanitized_name in metric_data
-            assert "step" in metric_data
+        metric_value = get_metric_data(metric, tmpdir)
+        # Assert that the correct model selection has been performed
+        # Check it by seeing if the values in the json has been updated
+        if metric.model_selection_operator:
+            try:
+                initial_value = OPERATOR_INITIAL_VALUE_MAP[
+                    metric.model_selection_operator
+                ]
+            except KeyError:
+                raise ValueError(
+                    "Please add the initial value for this "
+                    "operator to OPERATOR_INITIAL_VALUE_MAP"
+                )
 
-            # Assert that the correct model selection has been performed
-            # Check it by seeing if the values in the json has been updated
-            if metric.model_selection_operator:
-                try:
-                    initial_value = OPERATOR_INITIAL_VALUE_MAP[
-                        metric.model_selection_operator
-                    ]
-                except KeyError:
-                    raise ValueError(
-                        "Please add the initial value for this operator to OPERATOR_INITIAL_VALUE_MAP"
-                    )
-                assert metric_data[metric.sanitized_name] != initial_value
+            assert metric_value != initial_value
 
 
 # -------------------------------------------------------------------------------------
 
 
-@pytest.mark.parametrize("training_loop", [fake_classifier_training_loop])
-def test_metrics_names_collision(training_loop, tmpdir):
+def test_metrics_names_collision(tmpdir):
     """
     Test that an exception is correctly raised when two metrics have the same name.
 
     WHEN two or more metrics passed to a trainer have the same name
         THEN raise a ValueError
     """
-    metrics = [ClassifierLoss(name="test_loss"), ClassifierLoss(name="test_loss")]
+    metrics = [
+        ClassifierLoss(name="test_loss"),
+        ClassifierLoss(name="test_loss"),
+    ]
+
     with pytest.raises(ValueError):
-        training_loop(metrics=metrics, logdir=tmpdir)
+        # Since names collision is checked by the primitive Trainer we can test it easily
+        # with just one FakeTraining and be assured that it works.
+        FakeAdversarialTraining(tmpdir, metrics=metrics)
+
+
+# -------------------------------------------------------------------------------------
+
+
+# def test_metrics_on_restart(fake_training, tmpdir):
+#     """Test that metrics are correctly read on train restart."""
+
+#     def _train(fake_training, tmpdir):
+#         training_loop, loop_args, metrics = fake_training
+#         training_completed, trainer = training_loop(
+#             logdir=tmpdir, metrics=metrics, **loop_args
+#         )
+#         assert training_completed
+#         # Read and store the values of the metrics
+#         metrics_values = {
+#             metric.name: get_metric_data(metric, tmpdir) for metric in trainer._metrics
+#         }
+#         return metrics_values
+
+#     t1_values = _train(fake_training, tmpdir)
+#     t2_values = _train(fake_training, tmpdir)
+#     assert t1_values == t2_values

--- a/tests/test_trainers.py
+++ b/tests/test_trainers.py
@@ -41,6 +41,7 @@ def test_correct_trainer_restoration_on_restart(fake_training_fn, tmpdir):
         trained_model = fake_training.trainer._model
 
         new_training: FakeClassifierTraining = fake_training_fn(logdir=logdir)
+        new_training.trainer._build_and_restore_models(new_training.dataset)
         restored_model = new_training.trainer._model
 
         _check_models_weights(trained_model, restored_model)

--- a/tests/test_trainers.py
+++ b/tests/test_trainers.py
@@ -18,20 +18,58 @@ from pathlib import Path
 from typing import List
 
 import ashpy
+import pytest
+import tensorflow as tf
+from ashpy.trainers import AdversarialTrainer, ClassifierTrainer
+
+from tests.test_restorers import ModelNotConstructedError, _check_models_weights
+from tests.utils.fake_training_loop import (
+    FakeAdversarialTraining,
+    FakeClassifierTraining,
+    FakeTraining,
+)
 
 
-def test_generate_human_ckpt_dict(fake_training, tmpdir):
+def test_correct_trainer_restoration_on_restart(fake_training_fn, tmpdir):
+    logdir = Path(tmpdir)
+
+    fake_training: FakeTraining = fake_training_fn(logdir=logdir)
+    assert fake_training()
+
+    if isinstance(fake_training, FakeClassifierTraining):
+        assert isinstance(fake_training.trainer, ClassifierTrainer)
+        trained_model = fake_training.trainer._model
+
+        new_training: FakeClassifierTraining = fake_training_fn(logdir=logdir)
+        restored_model = new_training.trainer._model
+
+        _check_models_weights(trained_model, restored_model)
+
+    if isinstance(fake_training, FakeAdversarialTraining):
+        assert isinstance(fake_training.trainer, AdversarialTrainer)
+        trained_g = fake_training.trainer._generator
+        trained_d = fake_training.trainer._discriminator
+
+        new_training: FakeAdversarialTraining = fake_training_fn(logdir=logdir)
+        new_training.trainer._build_and_restore_models(new_training.dataset)
+        restored_g = new_training.trainer._generator
+        restored_d = new_training.trainer._discriminator
+        _check_models_weights(trained_g, restored_g)
+        _check_models_weights(trained_d, restored_d)
+
+
+def test_generate_human_ckpt_dict(fake_training_fn, tmpdir):
     """
     Test that the generation of the human readable map of the ckpt_dict works.
 
     TODO: improve the test.
     """
     logdir = Path(tmpdir)
-    training_loop, loop_args, metrics = fake_training
-    training_completed, trainer = training_loop(
-        logdir=logdir, metrics=metrics, **loop_args
-    )
-    assert training_completed
+    fake_training = fake_training_fn(logdir=logdir)
+    assert fake_training()
+
+    trainer = fake_training.trainer
+
     assert trainer._checkpoint_map
     assert (Path(trainer._ckpts_dir) / "checkpoint_map.json").exists()
     metrics: List[ashpy.metrics.Metric] = trainer._metrics

--- a/tests/utils/fake_training_loop.py
+++ b/tests/utils/fake_training_loop.py
@@ -97,13 +97,13 @@ class FakeClassifierTraining(FakeTraining):
         )
         self.metrics = metrics
 
-    def __call__(self) -> int:
+    def __call__(self) -> bool:
         self.trainer(
             self.dataset,
             self.dataset,
             measure_performance_freq=self.measure_performance_freq,
         )
-        return 1
+        return True
 
 
 # ---------------------------------------------------------------------------------
@@ -185,8 +185,8 @@ class FakeAdversarialTraining(FakeTraining):
             channels=channels,
         )
 
-    def __call__(self) -> int:
+    def __call__(self) -> bool:
         self.trainer(
             self.dataset, measure_performance_freq=self.measure_performance_freq
         )
-        return 1
+        return True


### PR DESCRIPTION
## Description

- Hunted down side-effects in metrics and callbacks. Enforcing conversion to `tuple` when necessary. These side effects were especially bothersome at test time.
- Added (back) model restoration on Trainer restart. Restoration is now done via `Restorer` and I have also added logic for deferred model restoration when dealing with sub-classed models.
- Fixed #42 and added tests for it

---

Fixes #42 

## Type of change

Please delete options that are not relevant.

- [x] Bugfix (i.e., a non-breaking change which fixes an issue)
- [x] New feature (i.e., a non-breaking change which adds functionality)
- [x] Breaking change (i.e., a fix or feature that would cause existing functionality to not work as expected)
- [x] This change requires a documentation update

## How Has This Been Tested?

`tox`

## Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented on my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings. One of the changes actively introduces a warning.
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
